### PR TITLE
Core 0.2.1 - MessageTap

### DIFF
--- a/src/Nodsoft.YumeChan.Core/Nodsoft.YumeChan.Core.csproj
+++ b/src/Nodsoft.YumeChan.Core/Nodsoft.YumeChan.Core.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
-		<Version>0.2.0</Version>
+		<Version>0.2.1</Version>
 		<Authors>DJ Daemonix</Authors>
 		<Company>Nodsoft ES</Company>
 		<Product>YumeChan</Product>
@@ -11,8 +11,8 @@
 		<RepositoryUrl>https://github.com/DJDaemonix/YumeChan</RepositoryUrl>
 		<RepositoryType>Git</RepositoryType>
 		<SignAssembly>false</SignAssembly>
-		<AssemblyVersion>0.2.0.0</AssemblyVersion>
-		<FileVersion>0.2.0.0</FileVersion>
+		<AssemblyVersion>0.2.1.0</AssemblyVersion>
+		<FileVersion>0.2.1.0</FileVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Nodsoft.YumeChan.Core/YumeCore.cs
+++ b/src/Nodsoft.YumeChan.Core/YumeCore.cs
@@ -157,10 +157,8 @@ namespace Nodsoft.YumeChan.Core
 					await module.LoadPlugin();
 					await Commands.AddModulesAsync(module.GetType().Assembly, Services);
 
-					if (module is IMessageTap)
+					if (module is IMessageTap tap)
 					{
-						IMessageTap tap = module as IMessageTap;
-
 						Client.MessageReceived += tap.OnMessageReceived;
 						Client.MessageUpdated += tap.OnMessageUpdated;
 						Client.MessageDeleted += tap.OnMessageDeleted;
@@ -177,10 +175,8 @@ namespace Nodsoft.YumeChan.Core
 
 			foreach (IPlugin plugin in Plugins)
 			{
-				if (plugin is IMessageTap)
+				if (plugin is IMessageTap tap)
 				{
-					IMessageTap tap = plugin as IMessageTap;
-
 					Client.MessageReceived -= tap.OnMessageReceived;
 					Client.MessageUpdated -= tap.OnMessageUpdated;
 					Client.MessageDeleted -= tap.OnMessageDeleted;


### PR DESCRIPTION
Requested by a fellow Plugin Developer ([BloodyTakao/BloodysServerGuard](https://github.com/BloodyTakao/BloodysServerGuard)), this feature will finally allow you to tap into these events :
 - Client.MessageReceived
 - Client.MessageUpdated
 - Client.MessageDeleted