### PR TITLE
Rework MongoDB Implementation with Generic ID constraint

### DIFF
--- a/src/Nodsoft.YumeChan.Core/Tools/DatabaseProvider.cs
+++ b/src/Nodsoft.YumeChan.Core/Tools/DatabaseProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+using MongoDbGenericRepository;
 using Nodsoft.YumeChan.Core.Config;
 using Nodsoft.YumeChan.PluginBase;
 using Nodsoft.YumeChan.PluginBase.Tools.Data;
@@ -24,6 +25,12 @@ namespace Nodsoft.YumeChan.Core.Tools
 			this.databaseName = databaseName;
 		}
 
-		public IEntityRepository<TEntity> GetEntityRepository<TEntity>() where TEntity : IDocument => new EntityRepository<TEntity>(connectionString, databaseName);
+
+		public IEntityRepository<TDocument, TKey> GetEntityRepository<TDocument, TKey>()
+			where TDocument : IDocument<TKey>
+			where TKey : IEquatable<TKey>
+		{ 
+			return new EntityRepository<TDocument, TKey>(connectionString, databaseName); 
+		}
 	}
 }

--- a/src/Nodsoft.YumeChan.Core/Tools/DatabaseProvider.cs
+++ b/src/Nodsoft.YumeChan.Core/Tools/DatabaseProvider.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using System.Data;
-using MongoDbGenericRepository;
 using Nodsoft.YumeChan.Core.Config;
 using Nodsoft.YumeChan.PluginBase;
 using Nodsoft.YumeChan.PluginBase.Tools.Data;
+
+
 
 namespace Nodsoft.YumeChan.Core.Tools
 {

--- a/src/Nodsoft.YumeChan.Core/Tools/EntityRepository.cs
+++ b/src/Nodsoft.YumeChan.Core/Tools/EntityRepository.cs
@@ -1,154 +1,67 @@
-﻿using MongoDB.Bson;
-using MongoDB.Driver;
+﻿using MongoDB.Driver;
 using Nodsoft.YumeChan.Core.Config;
 using Nodsoft.YumeChan.PluginBase.Tools.Data;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Nodsoft.YumeChan.Core.Tools
 {
-	public class EntityRepository<TDocument> : IEntityRepository<TDocument> where TDocument : IDocument
+	public class EntityRepository<TDocument, TKey> : IEntityRepository<TDocument, TKey>
+		where TDocument : IDocument<TKey>
+		where TKey : IEquatable<TKey>
 	{
-		private readonly IMongoCollection<TDocument> collection;
+		public IMongoCollection<TDocument> Collection { get; private set; }
 
 		public EntityRepository(ICoreDatabaseProperties settings)
 		{
 			IMongoDatabase database = new MongoClient(settings.ConnectionString).GetDatabase(settings.DatabaseName);
-			collection = database.GetCollection<TDocument>(GetCollectionName(typeof(TDocument)) ?? typeof(TDocument).Name);
+			Collection = database.GetCollection<TDocument>(typeof(TDocument).Name);
 		}
 
 		public EntityRepository(string connectionString, string databaseName)
 		{
 			IMongoDatabase database = new MongoClient(connectionString).GetDatabase(databaseName);
-			collection = database.GetCollection<TDocument>(GetCollectionName(typeof(TDocument)) ?? typeof(TDocument).Name);
+			Collection = database.GetCollection<TDocument>(typeof(TDocument).Name);
 		}
 
-		private protected string GetCollectionName(Type documentType)
-		{
-			return ((BsonCollectionAttribute)documentType.GetCustomAttributes(
-					typeof(BsonCollectionAttribute),
-					true)
-				.FirstOrDefault())?.CollectionName;
-		}
 
-		public virtual IQueryable<TDocument> AsQueryable()
-		{
-			return collection.AsQueryable();
-		}
 
-		public virtual IEnumerable<TDocument> FilterBy(
-			Expression<Func<TDocument, bool>> filterExpression)
-		{
-			return collection.Find(filterExpression).ToEnumerable();
-		}
+		public virtual IQueryable<TDocument> AsQueryable() => Collection.AsQueryable();
 
+		public virtual IEnumerable<TDocument> FilterBy(Expression<Func<TDocument, bool>> filterExpression) => Collection.Find(filterExpression).ToEnumerable();
 		public virtual IEnumerable<TProjected> FilterBy<TProjected>(
-			Expression<Func<TDocument, bool>> filterExpression,
+			Expression<Func<TDocument, bool>> filterExpression, 
 			Expression<Func<TDocument, TProjected>> projectionExpression)
 		{
-			return collection.Find(filterExpression).Project(projectionExpression).ToEnumerable();
+			return Collection.Find(filterExpression).Project(projectionExpression).ToEnumerable();
 		}
 
-		public virtual TDocument FindOne(Expression<Func<TDocument, bool>> filterExpression)
-		{
-			return collection.Find(filterExpression).FirstOrDefault();
-		}
+		public virtual TDocument FindOne(Expression<Func<TDocument, bool>> filterExpression) => Collection.Find(filterExpression).FirstOrDefault();
+		public virtual Task<TDocument> FindOneAsync(Expression<Func<TDocument, bool>> filterExpression) => Task.Run(() => Collection.Find(filterExpression).FirstOrDefaultAsync());
 
-		public virtual Task<TDocument> FindOneAsync(Expression<Func<TDocument, bool>> filterExpression)
-		{
-			return Task.Run(() => collection.Find(filterExpression).FirstOrDefaultAsync());
-		}
-
-		public virtual TDocument FindById(string id)
-		{
-			var objectId = new ObjectId(id);
-			var filter = Builders<TDocument>.Filter.Eq(doc => doc.Id, objectId);
-			return collection.Find(filter).SingleOrDefault();
-		}
-
-		public virtual Task<TDocument> FindByIdAsync(string id)
-		{
-			return Task.Run(() =>
-			{
-				var objectId = new ObjectId(id);
-				var filter = Builders<TDocument>.Filter.Eq(doc => doc.Id, objectId);
-				return collection.Find(filter).SingleOrDefaultAsync();
-			});
-		}
+		public virtual TDocument FindById(TKey id) => Collection.Find(Builders<TDocument>.Filter.Eq(doc => doc.Id, id)).SingleOrDefault();
+		public virtual Task<TDocument> FindByIdAsync(TKey id) => Task.Run(() => Collection.Find(Builders<TDocument>.Filter.Eq(doc => doc.Id, id)).SingleOrDefaultAsync());
 
 
-		public virtual void InsertOne(TDocument document)
-		{
-			collection.InsertOne(document);
-		}
+		public virtual void InsertOne(TDocument document) => Collection.InsertOne(document);
+		public virtual Task InsertOneAsync(TDocument document) => Task.Run(() => Collection.InsertOneAsync(document));
 
-		public virtual Task InsertOneAsync(TDocument document)
-		{
-			return Task.Run(() => collection.InsertOneAsync(document));
-		}
+		public void InsertMany(ICollection<TDocument> documents) => Collection.InsertMany(documents);
+		public virtual async Task InsertManyAsync(ICollection<TDocument> documents) => await Collection.InsertManyAsync(documents);
 
-		public void InsertMany(ICollection<TDocument> documents)
-		{
-			collection.InsertMany(documents);
-		}
+		public void ReplaceOne(TDocument document) => Collection.FindOneAndReplace(Builders<TDocument>.Filter.Eq(doc => doc.Id, document.Id), document);
+		public virtual async Task ReplaceOneAsync(TDocument document) => await Collection.FindOneAndReplaceAsync(Builders<TDocument>.Filter.Eq(doc => doc.Id, document.Id), document);
 
+		public void DeleteOne(Expression<Func<TDocument, bool>> filterExpression) => Collection.FindOneAndDelete(filterExpression);
+		public Task DeleteOneAsync(Expression<Func<TDocument, bool>> filterExpression) => Task.Run(() => Collection.FindOneAndDeleteAsync(filterExpression));
 
-		public virtual async Task InsertManyAsync(ICollection<TDocument> documents)
-		{
-			await collection.InsertManyAsync(documents);
-		}
+		public void DeleteById(TKey id) => Collection.FindOneAndDelete(Builders<TDocument>.Filter.Eq(doc => doc.Id, id));
+		public Task DeleteByIdAsync(TKey id) => Task.Run(() => Collection.FindOneAndDeleteAsync(Builders<TDocument>.Filter.Eq(doc => doc.Id, id)));
 
-		public void ReplaceOne(TDocument document)
-		{
-			var filter = Builders<TDocument>.Filter.Eq(doc => doc.Id, document.Id);
-			collection.FindOneAndReplace(filter, document);
-		}
-
-		public virtual async Task ReplaceOneAsync(TDocument document)
-		{
-			var filter = Builders<TDocument>.Filter.Eq(doc => doc.Id, document.Id);
-			await collection.FindOneAndReplaceAsync(filter, document);
-		}
-
-		public void DeleteOne(Expression<Func<TDocument, bool>> filterExpression)
-		{
-			collection.FindOneAndDelete(filterExpression);
-		}
-
-		public Task DeleteOneAsync(Expression<Func<TDocument, bool>> filterExpression)
-		{
-			return Task.Run(() => collection.FindOneAndDeleteAsync(filterExpression));
-		}
-
-		public void DeleteById(string id)
-		{
-			var objectId = new ObjectId(id);
-			var filter = Builders<TDocument>.Filter.Eq(doc => doc.Id, objectId);
-			collection.FindOneAndDelete(filter);
-		}
-
-		public Task DeleteByIdAsync(string id)
-		{
-			return Task.Run(() =>
-			{
-				var objectId = new ObjectId(id);
-				var filter = Builders<TDocument>.Filter.Eq(doc => doc.Id, objectId);
-				collection.FindOneAndDeleteAsync(filter);
-			});
-		}
-
-		public void DeleteMany(Expression<Func<TDocument, bool>> filterExpression)
-		{
-			collection.DeleteMany(filterExpression);
-		}
-
-		public Task DeleteManyAsync(Expression<Func<TDocument, bool>> filterExpression)
-		{
-			return Task.Run(() => collection.DeleteManyAsync(filterExpression));
-		}
+		public void DeleteMany(Expression<Func<TDocument, bool>> filterExpression) => Collection.DeleteMany(filterExpression);
+		public Task DeleteManyAsync(Expression<Func<TDocument, bool>> filterExpression) => Task.Run(() => Collection.DeleteManyAsync(filterExpression));
 	}
 }


### PR DESCRIPTION
Current system constrains the ID to MongoDB's ObjectId, which is impractical to work with in Discord.NET's case.

Reworked to Generic ID, so that any value can be used for IDs.